### PR TITLE
Declare GAC and VSIX elements in project definition

### DIFF
--- a/Build/Projects/Protobuild.IDE.VisualStudio.definition
+++ b/Build/Projects/Protobuild.IDE.VisualStudio.definition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ExternalProject Name="Protobuild.IDE.VisualStudio">
+<ExternalProject Name="Protobuild.IDE.VisualStudio" SkipAutopackage="True">
 
   <Project 
     Name="Protobuild.IDE.VisualStudio"

--- a/Build/Protobuild.IDE.VisualStudio.External.definition
+++ b/Build/Protobuild.IDE.VisualStudio.External.definition
@@ -4,5 +4,10 @@
   <Binary 
     Name="Protobuild.IDE.VisualStudio"
     Path="NoVSIX/Protobuild.IDE.VisualStudio.Wizard.dll" />
+  <GAC 
+    Name="Protobuild.IDE.VisualStudio"
+    Path="NoVSIX/Protobuild.IDE.VisualStudio.Wizard.dll" />
+  <VSIX
+    Path="VSIX/Protobuild.IDE.VisualStudio.vsix" />
   
 </ExternalProject>


### PR DESCRIPTION
This makes use of the upcoming feature in Protobuild to install VSIXs and GAC assemblies directly, without special logic in Protobuild Manager.